### PR TITLE
Feat/refresh token

### DIFF
--- a/controllers/authController.js
+++ b/controllers/authController.js
@@ -34,34 +34,31 @@ const createToken = (req, res) => {
     id: user.id,
     email: user.email,
   };
-  // const refreshPayload = {
-  //   id: user.id,
-  // };
+  const refreshPayload = {
+    id: user.id,
+  };
   
   const accessToken = jwt.sign(accessPayload, process.env.JWT_SECRET, {
     subject: "user",
-    expiresIn: "10m",
+    expiresIn: "3m",
     issuer: process.env.JWT_ISSUER,
   });
-  // const refreshToken = jwt.sign(refreshPayload, process.env.JWT_REFRESH_SECRET, {
-  //   subject: "user",
-  //   expiresIn: "7d", // 7 days
-  //   issuer: process.env.JWT_ISSUER,
-  // });
-
-  // user.refreshToken = refreshToken;
-  // user.save();
+  const refreshToken = jwt.sign(refreshPayload, process.env.JWT_REFRESH_SECRET, {
+    subject: "user",
+    expiresIn: "7d", // 7 days
+    issuer: process.env.JWT_ISSUER,
+  });
 
   res.cookie("accessToken", accessToken, {
     httpOnly: true,
     sameSite: "strict",
     secure: true,
   });
-  // res.cookie("refreshToken", refreshToken, {
-  //   httpOnly: true,
-  //   sameSite: "strict",
-  //   secure: true,
-  // });
+  res.cookie("refreshToken", refreshToken, {
+    httpOnly: true,
+    sameSite: "strict",
+    secure: true,
+  });
 
   res.status(StatusCodes.OK).end();
 };

--- a/middlewares/jwtMiddleware.js
+++ b/middlewares/jwtMiddleware.js
@@ -1,27 +1,127 @@
+// const jwt = require("jsonwebtoken");
+// const dotenv = require("dotenv");
+// const User = require("../models").Users;
+// const { StatusCodes } = require("http-status-codes");
+
+// dotenv.config({ path: "back/.env" });
+
+// const verifyToken = async (req, res, next) => {
+//   let token;
+//   if (req.header("Authorization"))
+//     token = req.header("Authorization").split(" ")[1];
+
+//   if (!token) return res.status(StatusCodes.UNAUTHORIZED).end();
+
+//   try {
+//     const decoded = jwt.verify(token, process.env.JWT_SECRET);
+//     req.userId = decoded.id;
+//     req.userEmail = decoded.email;
+//     // 여기서 이메일 사용
+//     return next();
+//   } catch (error) {
+//     if (error.name === "TokenExpiredError") {
+//       const refreshToken = req.cookies?.refreshToken;
+//       if (!refreshToken) return res.status(StatusCodes.UNAUTHORIZED).json({ message: "Refresh Token missing" });
+//       try {
+//         const decodedRefresh = jwt.verify(refreshToken, process.env.JWT_REFRESH_SECRET);
+//         //req.userId = decodedRefresh.id;
+//         const user = await User.findOne({ where: { id: decodedRefresh.id } });
+//         if (!user) {
+//           return res.status(StatusCodes.UNAUTHORIZED).json({ message: "User not found." });
+//         }
+//         const newAccessToken = jwt.sign({ id: user.id, email: user.email }, process.env.JWT_SECRET, {
+//           subject: "user",
+//           expiresIn: "10m",
+//           issuer: process.env.JWT_ISSUER,
+//         });
+//         res.cookie("accessToken", newAccessToken, {
+//           httpOnly: true,
+//           sameSite: "strict",
+//           secure: true,
+//         });
+//         return next();
+//       } catch (refreshError) {
+//         return res.status(StatusCodes.UNAUTHORIZED).json({ message: "Invalid or expired Refresh Token." });
+//       }
+//     }
+//   }
+// };
+
+// module.exports = {
+//   verifyToken,
+// };
+
 const jwt = require("jsonwebtoken");
 const dotenv = require("dotenv");
+const User = require("../models").Users;
 const { StatusCodes } = require("http-status-codes");
 
 dotenv.config({ path: "back/.env" });
 
-const verifyToken = (req, res, next) => {
-  let token;
-  if (req.header("Authorization"))
-    token = req.header("Authorization").split(" ")[1];
-
-  if (!token) return res.status(StatusCodes.UNAUTHORIZED).end();
-
+const verifyAccessToken = (token) => {
   try {
-    const decoded = jwt.verify(token, process.env.JWT_SECRET);
+    return jwt.verify(token, process.env.JWT_SECRET);
+  } catch (error) {
+    return null;
+  }
+};
+
+const verifyRefreshToken = async (refreshToken) => {
+  try {
+    const decodedRefresh = jwt.verify(refreshToken, process.env.JWT_REFRESH_SECRET);
+    console.log("Decoded Refresh Token:", decodedRefresh); 
+    const user = await User.findOne({ where: { id: decodedRefresh.id } });
+    if (!user) throw new Error("User not found");
+    return user;
+  } catch (error) {
+    throw new Error("Invalid or expired Refresh Token");
+  }
+};
+
+const verifyToken = async (req, res, next) => {
+  const authHeader = req.header("Authorization");
+  const token = authHeader ? authHeader.split(" ")[1] : null;
+
+  if (!token) {
+    return res.status(StatusCodes.UNAUTHORIZED).json({ message: "Access Token missing" });
+  }
+
+  const decoded = verifyAccessToken(token);
+  if (decoded) {
     req.userId = decoded.id;
     req.userEmail = decoded.email;
-    // 여기서 이메일 사용
-    next();
+    console.log(req.user);
+    return next();
+  }
+
+  // Handle expired access token
+  const refreshToken = req.cookies?.refreshToken;
+  if (!refreshToken) {
+    return res.status(StatusCodes.UNAUTHORIZED).json({ message: "Refresh Token missing" });
+  }
+
+  try {
+    const user = await verifyRefreshToken(refreshToken);
+    const newAccessToken = jwt.sign(
+      { id: user.id, email: user.email },
+      process.env.JWT_SECRET,
+      {
+        subject: "user",
+        expiresIn: "3m",
+        issuer: process.env.JWT_ISSUER,
+      }
+    );
+    res.cookie("accessToken", newAccessToken, {
+      httpOnly: true,
+      sameSite: "strict",
+      secure: true,
+    });
+    console.log(newAccessToken);
+    req.userId = user.id;
+    req.userEmail = user.email;
+    return next();
   } catch (error) {
-    if (error.name === "TokenExpiredError") {
-      return res.status(StatusCodes.UNAUTHORIZED).json({ message: "Token expired" });
-    }
-    return res.status(StatusCodes.UNAUTHORIZED).json({ message: "Invalid token" });
+    return res.status(StatusCodes.UNAUTHORIZED).json({ message: error.message });
   }
 };
 

--- a/models/users.js
+++ b/models/users.js
@@ -32,14 +32,6 @@ module.exports = (sequelize, DataTypes) => {
         allowNull: false,
         defaultValue: "user", // 기본값 설정 (ex: user, admin)
       },
-      // created_at: {
-      //   type: DataTypes.DATE,
-      //   defaultValue: DataTypes.NOW,
-      // },
-      // updated_at: {
-      //   type: DataTypes.DATE,
-      //   defaultValue: DataTypes.NOW,
-      // },
     },
     {
       tableName: "users",

--- a/routes/authRoute.js
+++ b/routes/authRoute.js
@@ -29,7 +29,7 @@ router.get(
     session: false,
     failureRedirect: "/auth/kakao",
   }),
-  createToken,
+  createToken, 
 );
 
 router.get(

--- a/routes/flightRoute.js
+++ b/routes/flightRoute.js
@@ -8,7 +8,6 @@ const { verifyToken } = require("../middlewares/jwtMiddleware");
 
 router.use(express.json());
 
-
 router.post("/search", searchFlights);
 router.get("/:flightId", verifyToken, getFlightDetails);
 

--- a/routes/ticketRoute.js
+++ b/routes/ticketRoute.js
@@ -8,10 +8,9 @@ const router = express.Router();
 const { verifyToken } = require("../middlewares/jwtMiddleware");
 
 router.use(express.json());
-router.use(verifyToken);
 
-router.get("/:ticketId", getTicketByTicketId);
-router.get("/", getTicketsByUserId);
-router.post("/", postTickets);
+router.get("/:ticketId", verifyToken, getTicketByTicketId);
+router.get("/", verifyToken, getTicketsByUserId);
+router.post("/", verifyToken, postTickets);
 
 module.exports = router;


### PR DESCRIPTION
### 구현 내용
refreshToken을 이용해 토큰 만료시 자동연장 기능을 추가하였습니다.

1. 서버가 클라이언트에게 accessToken, refreshToken을 쿠키로 전달,
2. 클라이언트에서 요할 때 accessToken만 Authorization 헤더로 서버로 전달
3. 서버에서 accessToken만 검증, 요청 처리 or 401 반환
4. 만료시 401 오류 발생 -> 클라이언트에서 accessToken을 Authorization으로 refreshToken을 쿠키로 서버로 전달
5. 서버에서 accessToken 만료를 확인후 refreshToken을 검증 후 새로운 accessToken 을 쿠키에담아 클라이언트로 전달